### PR TITLE
feat: macOSネイティブサポートを追加 (#50)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -37,10 +37,19 @@ pub fn build(b: *std.Build) void {
     });
     test_step.dependOn(&b.addRunArtifact(src_tests).step);
 
+    const macos_sys_mod = b.createModule(.{
+        .root_source_file = b.path("src/utils/macos_sys.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
     const cpu_mod = b.createModule(.{
         .root_source_file = b.path("src/collector/cpu.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "../utils/macos_sys.zig", .module = macos_sys_mod },
+        },
     });
 
     const cpu_tests = b.addTest(.{
@@ -59,6 +68,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/collector/memory.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "../utils/macos_sys.zig", .module = macos_sys_mod },
+        },
     });
 
     const memory_tests = b.addTest(.{
@@ -77,6 +89,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/collector/disk.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "../utils/macos_sys.zig", .module = macos_sys_mod },
+        },
     });
 
     const disk_tests = b.addTest(.{
@@ -95,6 +110,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/collector/network.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "../utils/macos_sys.zig", .module = macos_sys_mod },
+        },
     });
 
     const network_tests = b.addTest(.{
@@ -113,6 +131,9 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/collector/loadavg.zig"),
         .target = target,
         .optimize = optimize,
+        .imports = &.{
+            .{ .name = "../utils/macos_sys.zig", .module = macos_sys_mod },
+        },
     });
 
     const loadavg_tests = b.addTest(.{

--- a/src/collector/cpu.zig
+++ b/src/collector/cpu.zig
@@ -1,6 +1,7 @@
-// /proc/stat パーサー
+// /proc/stat パーサー (Linux) / sysctlbyname (macOS)
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const MAX_CORES = 64;
 
@@ -88,6 +89,47 @@ pub fn parseSnapshot(content: []const u8) CpuSnapshot {
     }
 
     return snapshot;
+}
+
+/// macOS: sysctlbyname("kern.cp_time" / "kern.cp_times") から CpuSnapshot を収集する。
+/// CP_USER=0, CP_NICE=1, CP_SYS=2, CP_INTR=3, CP_IDLE=4 (CPUSTATES=5, sizeof(long)=8)
+pub fn collectMacos() CpuSnapshot {
+    const sys = @import("../utils/macos_sys.zig");
+    var snap = CpuSnapshot{};
+
+    // ── 全体 CPU 時間 (kern.cp_time) ─────────────────────────────────
+    var cp_time: [5]i64 = .{0} ** 5;
+    var cp_time_len: usize = @sizeOf(@TypeOf(cp_time));
+    _ = sys.sysctlbyname("kern.cp_time", &cp_time[0], &cp_time_len, null, 0);
+    snap.total = cpTimesToCpuTimes(&cp_time);
+
+    // ── コア別 CPU 時間 (kern.cp_times) ──────────────────────────────
+    var cp_times: [MAX_CORES * 5]i64 = .{0} ** (MAX_CORES * 5);
+    var cp_times_len: usize = @sizeOf(@TypeOf(cp_times));
+    _ = sys.sysctlbyname("kern.cp_times", &cp_times[0], &cp_times_len, null, 0);
+
+    const ncpus = cp_times_len / (5 * @sizeOf(i64));
+    const actual_cores = @min(ncpus, MAX_CORES);
+    snap.core_count = actual_cores;
+    if (ncpus > MAX_CORES) snap.truncated = true;
+
+    for (0..actual_cores) |i| {
+        const base = i * 5;
+        snap.cores[i] = cpTimesToCpuTimes(cp_times[base .. base + 5]);
+    }
+
+    return snap;
+}
+
+/// macOS の kern.cp_time[5] (i64 配列) を CpuTimes に変換する。
+fn cpTimesToCpuTimes(cp: []const i64) CpuTimes {
+    return CpuTimes{
+        .user = @intCast(if (cp[0] > 0) cp[0] else 0),
+        .nice = @intCast(if (cp[1] > 0) cp[1] else 0),
+        .system = @intCast(if (cp[2] > 0) cp[2] else 0),
+        .irq = @intCast(if (cp[3] > 0) cp[3] else 0),
+        .idle = @intCast(if (cp[4] > 0) cp[4] else 0),
+    };
 }
 
 /// 前回・今回の CpuTimes 差分から CPU 使用率 (0.0〜100.0) を計算する。

--- a/src/collector/disk.zig
+++ b/src/collector/disk.zig
@@ -1,6 +1,7 @@
-// /proc/mounts + statvfs パーサー
+// /proc/mounts + statfs (Linux) / getfsstat (macOS)
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const MAX_MOUNTS = 32;
 /// Linux PATH_MAX
@@ -134,6 +135,50 @@ pub fn statDisk(mount_point: []const u8) !DiskStat {
     stat.total_blocks = sv.f_blocks;
     stat.avail_blocks = sv.f_bavail;
     return stat;
+}
+
+/// macOS: getfsstat() を呼び出して DiskSnapshot を返す。
+/// MNT_LOCAL フラグを持つ実ファイルシステムのみを対象とする。
+pub fn collectMacos() DiskSnapshot {
+    const sys = @import("../utils/macos_sys.zig");
+    var snapshot = DiskSnapshot{};
+
+    // バッファサイズを固定配列で確保 (スタック上)
+    var buf: [MAX_MOUNTS]sys.MacStatfs = undefined;
+    const buf_size: i32 = @intCast(@sizeOf(sys.MacStatfs) * MAX_MOUNTS);
+    const n = sys.getfsstat(@as(?[*]sys.MacStatfs, @ptrCast(&buf)), buf_size, sys.MNT_NOWAIT);
+    if (n <= 0) return snapshot;
+
+    const count = @as(usize, @intCast(n));
+    for (0..count) |i| {
+        const sf = &buf[i];
+
+        // MNT_LOCAL ビットが立っていないものは除外 (NFS等)
+        if ((sf.f_flags & sys.MNT_LOCAL) == 0) continue;
+        // totalBytes が 0 のものは除外
+        if (sf.f_blocks == 0) continue;
+
+        if (snapshot.count >= MAX_MOUNTS) {
+            snapshot.truncated = true;
+            break;
+        }
+
+        // マウントポイント文字列長を計算
+        const mp_raw: []const u8 = std.mem.sliceTo(&sf.f_mntonname, 0);
+        const mp_len = @min(mp_raw.len, 255);
+
+        var stat = DiskStat{};
+        @memcpy(stat.mount_point[0..mp_len], mp_raw[0..mp_len]);
+        stat.mount_point_len = mp_len;
+        stat.block_size = @as(u64, sf.f_bsize);
+        stat.total_blocks = sf.f_blocks;
+        stat.avail_blocks = sf.f_bavail;
+
+        snapshot.stats[snapshot.count] = stat;
+        snapshot.count += 1;
+    }
+
+    return snapshot;
 }
 
 /// /proc/mounts の内容をパースし、各マウントポイントで statvfs() を実行して

--- a/src/collector/loadavg.zig
+++ b/src/collector/loadavg.zig
@@ -1,6 +1,7 @@
-// /proc/loadavg パーサー
+// /proc/loadavg パーサー (Linux) / getloadavg (macOS)
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// /proc/loadavg から取得したロードアベレージ情報
 pub const LoadAvg = struct {
@@ -17,6 +18,20 @@ pub const LoadAvg = struct {
     /// 最後に作成されたプロセスのPID
     last_pid: u32 = 0,
 };
+
+/// macOS: getloadavg(3) からロードアベレージを取得する。
+/// running / total / last_pid は macOS では取得不可のため 0 のまま。
+pub fn collectMacos() LoadAvg {
+    const sys = @import("../utils/macos_sys.zig");
+    var avgs: [3]f64 = .{ 0.0, 0.0, 0.0 };
+    const ret = sys.getloadavg(@as([*]f64, &avgs), 3);
+    if (ret < 0) return LoadAvg{};
+    return LoadAvg{
+        .load1 = avgs[0],
+        .load5 = avgs[1],
+        .load15 = avgs[2],
+    };
+}
 
 /// /proc/loadavg の内容をパースして LoadAvg を返す。
 /// フォーマット: "1m 5m 15m running/total last_pid\n"

--- a/src/collector/memory.zig
+++ b/src/collector/memory.zig
@@ -1,6 +1,7 @@
-// /proc/meminfo パーサー
+// /proc/meminfo パーサー (Linux) / sysctl + host_statistics64 (macOS)
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 /// /proc/meminfo から取得したメモリ情報 (単位: kB)
 pub const MemInfo = struct {
@@ -38,6 +39,55 @@ pub fn parseMemLine(line: []const u8) ?struct { key: []const u8, value: u64 } {
     const value = std.fmt.parseInt(u64, val_str, 10) catch return null;
 
     return .{ .key = key, .value = value };
+}
+
+/// macOS: sysctlbyname + host_statistics64 からメモリ情報を収集する。
+/// - hw.memsize → 物理メモリ合計 (bytes)
+/// - host_statistics64(HOST_VM_INFO64) → free / inactive / speculative ページ数
+/// - vm.swapusage → スワップ使用量
+/// available = (free + inactive + speculative) * page_size
+pub fn collectMacos() MemInfo {
+    const sys = @import("../utils/macos_sys.zig");
+    var info = MemInfo{};
+
+    // ── 物理メモリ合計 ─────────────────────────────────────────────
+    var mem_size: u64 = 0;
+    var mem_size_len: usize = @sizeOf(u64);
+    _ = sys.sysctlbyname("hw.memsize", &mem_size, &mem_size_len, null, 0);
+    info.mem_total = mem_size / 1024;
+
+    // ── ページサイズ取得 ──────────────────────────────────────────
+    var page_size: u32 = 16384;
+    var page_size_len: usize = @sizeOf(u32);
+    _ = sys.sysctlbyname("hw.pagesize", &page_size, &page_size_len, null, 0);
+
+    // ── VM 統計 (vm_statistics64) ──────────────────────────────────
+    var vm_info: [sys.HOST_VM_INFO64_COUNT]u32 = .{0} ** sys.HOST_VM_INFO64_COUNT;
+    var vm_count: sys.mach_msg_type_number_t = sys.HOST_VM_INFO64_COUNT;
+    const kr = sys.host_statistics64(
+        sys.mach_host_self(),
+        sys.HOST_VM_INFO64,
+        @as([*]u32, &vm_info),
+        &vm_count,
+    );
+    if (kr == 0) {
+        const free_pages: u64 = vm_info[sys.VM_STAT64_FREE_IDX];
+        const inactive_pages: u64 = vm_info[sys.VM_STAT64_INACTIVE_IDX];
+        const speculative_pages: u64 = vm_info[sys.VM_STAT64_SPECULATIVE_IDX];
+        const available_bytes = (free_pages + inactive_pages + speculative_pages) *
+            @as(u64, page_size);
+        info.mem_available = available_bytes / 1024;
+        info.mem_free = (free_pages * @as(u64, page_size)) / 1024;
+    }
+
+    // ── スワップ使用量 ─────────────────────────────────────────────
+    var swap: sys.XswUsage = std.mem.zeroes(sys.XswUsage);
+    var swap_len: usize = @sizeOf(sys.XswUsage);
+    _ = sys.sysctlbyname("vm.swapusage", &swap, &swap_len, null, 0);
+    info.swap_total = swap.xsu_total / 1024;
+    info.swap_free = swap.xsu_avail / 1024;
+
+    return info;
 }
 
 /// /proc/meminfo の内容をパースして MemInfo を返す。

--- a/src/collector/network.zig
+++ b/src/collector/network.zig
@@ -1,6 +1,7 @@
-// /proc/net/dev パーサー
+// /proc/net/dev パーサー (Linux) / getifaddrs (macOS)
 
 const std = @import("std");
+const builtin = @import("builtin");
 
 pub const MAX_IFACES = 32;
 /// インターフェース名の最大長
@@ -70,6 +71,54 @@ pub fn parseNetLine(line: []const u8) ?NetIfStat {
     stat.name_len = raw_name.len;
 
     return stat;
+}
+
+/// macOS: getifaddrs() で AF_LINK エントリを走査し NetSnapshot を返す。
+/// ifa_data が指す if_data から ifi_ibytes / ifi_obytes を読み取る。
+pub fn collectMacos() NetSnapshot {
+    const sys = @import("../utils/macos_sys.zig");
+    var snapshot = NetSnapshot{};
+
+    var ifap: *sys.Ifaddrs = undefined;
+    if (sys.getifaddrs(&ifap) != 0) return snapshot;
+    defer sys.freeifaddrs(ifap);
+
+    var ifa: ?*sys.Ifaddrs = ifap;
+    while (ifa) |iface| : (ifa = iface.ifa_next) {
+        // ifa_addr が null の場合はスキップ
+        const addr_ptr = iface.ifa_addr orelse continue;
+
+        // sa_family は macOS では sa_len(u8)@0, sa_family(u8)@1
+        const sa_bytes: [*]const u8 = @ptrCast(addr_ptr);
+        const sa_family = sa_bytes[1];
+        if (sa_family != sys.AF_LINK) continue;
+
+        // ifa_data が null の場合はスキップ
+        const data_ptr = iface.ifa_data orelse continue;
+        const if_data: *const sys.IfData = @ptrCast(@alignCast(data_ptr));
+
+        // インターフェース名
+        const name_ptr = iface.ifa_name orelse continue;
+        const raw_name = std.mem.sliceTo(name_ptr, 0);
+        if (raw_name.len == 0 or raw_name.len >= IFNAME_MAX) continue;
+
+        if (snapshot.count >= MAX_IFACES) {
+            snapshot.truncated = true;
+            break;
+        }
+
+        var stat = NetIfStat{
+            .rx_bytes = if_data.ifi_ibytes,
+            .tx_bytes = if_data.ifi_obytes,
+        };
+        @memcpy(stat.name[0..raw_name.len], raw_name);
+        stat.name_len = raw_name.len;
+
+        snapshot.ifaces[snapshot.count] = stat;
+        snapshot.count += 1;
+    }
+
+    return snapshot;
 }
 
 /// /proc/net/dev の内容をパースして NetSnapshot を返す。

--- a/src/collector/process.zig
+++ b/src/collector/process.zig
@@ -1,6 +1,7 @@
-// Top N プロセス収集
+// Top N プロセス収集 (Linux: /proc 走査, macOS: スタブ)
 
 const std = @import("std");
+const builtin = @import("builtin");
 const proc_reader = @import("../utils/proc_reader.zig");
 
 /// CPU 上位プロセスの最大取得数
@@ -104,7 +105,14 @@ fn prevTicksForPid(prev: *const ProcessSnapshot, pid: u32) ?u64 {
 /// /proc 以下を走査して CPU 上位 TOP_N プロセスのスナップショットを返す。
 /// prev は前回のスナップショット（null の場合は CPU% = 0.0）。
 /// buf は一時読み取りバッファ（proc_reader.PROC_BUF_SIZE 以上推奨）。
+/// macOS では /proc が存在しないため空のスナップショットを返す。
 pub fn collect(prev: ?*const ProcessSnapshot, buf: []u8) ProcessSnapshot {
+    if (comptime builtin.os.tag == .macos) {
+        var snap = ProcessSnapshot{};
+        snap.timestamp_ns = std.time.nanoTimestamp();
+        return snap;
+    }
+
     var snap = ProcessSnapshot{};
     snap.timestamp_ns = std.time.nanoTimestamp();
 

--- a/src/collector/snapshot.zig
+++ b/src/collector/snapshot.zig
@@ -1,6 +1,7 @@
 // 全メトリクスの1時点構造体
 
 const std = @import("std");
+const builtin = @import("builtin");
 const cpu_mod = @import("cpu.zig");
 const memory_mod = @import("memory.zig");
 const disk_mod = @import("disk.zig");
@@ -43,32 +44,42 @@ pub const UsageSnapshot = struct {
     net_count: usize = 0,
 };
 
-/// /proc 以下の各ファイルを読み取り、現在の Snapshot を返す。
-/// buf は proc_reader.PROC_BUF_SIZE (64 KB) 以上を推奨。
-/// 各ファイルの読み取りに失敗した場合はそのフィールドをゼロ値のままにする。
+/// 現在の Snapshot を返す。
+/// macOS では sysctl / mach API を使用する。
+/// Linux では /proc 以下の各ファイルを読み取る。
+/// buf は Linux 専用 (proc_reader.PROC_BUF_SIZE = 64 KB 以上推奨)。
 pub fn collect(buf: []u8) Snapshot {
     var snap = Snapshot{};
     snap.timestamp_ns = std.time.nanoTimestamp();
 
-    if (proc_reader.read("/proc/stat", buf)) |content| {
-        snap.cpu = cpu_mod.parseSnapshot(content);
-    } else |_| {}
+    if (comptime builtin.os.tag == .macos) {
+        snap.cpu = cpu_mod.collectMacos();
+        snap.mem = memory_mod.collectMacos();
+        snap.disk = disk_mod.collectMacos();
+        snap.net = network_mod.collectMacos();
+        snap.load = loadavg_mod.collectMacos();
+    } else {
+        // Linux: /proc 以下を読み取る
+        if (proc_reader.read("/proc/stat", buf)) |content| {
+            snap.cpu = cpu_mod.parseSnapshot(content);
+        } else |_| {}
 
-    if (proc_reader.read("/proc/meminfo", buf)) |content| {
-        snap.mem = memory_mod.parseSnapshot(content);
-    } else |_| {}
+        if (proc_reader.read("/proc/meminfo", buf)) |content| {
+            snap.mem = memory_mod.parseSnapshot(content);
+        } else |_| {}
 
-    if (proc_reader.read("/proc/mounts", buf)) |content| {
-        snap.disk = disk_mod.collect(content);
-    } else |_| {}
+        if (proc_reader.read("/proc/mounts", buf)) |content| {
+            snap.disk = disk_mod.collect(content);
+        } else |_| {}
 
-    if (proc_reader.read("/proc/net/dev", buf)) |content| {
-        snap.net = network_mod.parseSnapshot(content);
-    } else |_| {}
+        if (proc_reader.read("/proc/net/dev", buf)) |content| {
+            snap.net = network_mod.parseSnapshot(content);
+        } else |_| {}
 
-    if (proc_reader.read("/proc/loadavg", buf)) |content| {
-        snap.load = loadavg_mod.parseSnapshot(content) orelse .{};
-    } else |_| {}
+        if (proc_reader.read("/proc/loadavg", buf)) |content| {
+            snap.load = loadavg_mod.parseSnapshot(content) orelse .{};
+        } else |_| {}
+    }
 
     return snap;
 }

--- a/src/render/widgets/bar.zig
+++ b/src/render/widgets/bar.zig
@@ -60,7 +60,7 @@ const BAR_TABLE: [101]BarBytes = blk: {
 /// 幅は BAR_WIDTH 文字固定。filled 部分に ANSI カラーを付与する。
 pub fn render(writer: anytype, pct: f64) !void {
     const clamped = @min(@max(pct, 0.0), 100.0);
-    const idx = @min(@as(usize, @intFromFloat(clamped)), 100);
+    const idx: usize = @min(@as(usize, @intFromFloat(clamped)), @as(usize, 100));
     const n_filled = idx * BAR_WIDTH / 100;
     const bar = &BAR_TABLE[idx];
 
@@ -77,14 +77,14 @@ pub fn render(writer: anytype, pct: f64) !void {
 /// カラーなしでプログレスバーを writer に書き込む (リダイレクト先など ANSI 非対応環境向け)。
 pub fn renderPlain(writer: anytype, pct: f64) !void {
     const clamped = @min(@max(pct, 0.0), 100.0);
-    const idx = @min(@as(usize, @intFromFloat(clamped)), 100);
+    const idx: usize = @min(@as(usize, @intFromFloat(clamped)), @as(usize, 100));
     try writer.writeAll(&BAR_TABLE[idx]);
 }
 
 /// HealthStatus に基づく色でプログレスバーを writer に書き込む。
 pub fn renderWithHealth(writer: anytype, pct: f64, status: health_color.HealthStatus) !void {
     const clamped = @min(@max(pct, 0.0), 100.0);
-    const idx = @min(@as(usize, @intFromFloat(clamped)), 100);
+    const idx: usize = @min(@as(usize, @intFromFloat(clamped)), @as(usize, 100));
     const n_filled = idx * @as(usize, BAR_WIDTH) / 100;
     const bar = &BAR_TABLE[idx];
 

--- a/src/utils/macos_sys.zig
+++ b/src/utils/macos_sys.zig
@@ -1,0 +1,141 @@
+// macOS システムコール・データ構造 extern 宣言
+// 本ファイルはコンパイル時 builtin.os.tag == .macos のときのみ使用する。
+
+const std = @import("std");
+
+// ── sysctl ─────────────────────────────────────────────────────────────
+pub extern "c" fn sysctlbyname(
+    name: [*:0]const u8,
+    oldp: ?*anyopaque,
+    oldlenp: ?*usize,
+    newp: ?*anyopaque,
+    newlen: usize,
+) c_int;
+
+// ── getloadavg ─────────────────────────────────────────────────────────
+pub extern "c" fn getloadavg(loadavg: [*]f64, nelem: c_int) c_int;
+
+// ── getfsstat ──────────────────────────────────────────────────────────
+pub const MNT_NOWAIT: c_int = 2;
+pub const MNT_LOCAL: u32 = 0x1000;
+
+/// macOS struct statfs (Apple Silicon 実測: sizeof=2168)
+/// オフセット:
+///   f_bsize(u32)@0, f_iosize(i32)@4, f_blocks(u64)@8, f_bfree(u64)@16,
+///   f_bavail(u64)@24, f_fsid([2]i32)@48, f_flags(u32)@64,
+///   f_mntonname([1024]u8)@88, f_mntfromname([1024]u8)@1112
+pub const MacStatfs = extern struct {
+    f_bsize: u32,
+    f_iosize: i32,
+    f_blocks: u64,
+    f_bfree: u64,
+    f_bavail: u64,
+    f_files: u64,
+    f_ffree: u64,
+    f_fsid: [2]i32,
+    f_owner: u32,
+    f_type: u32,
+    f_flags: u32,
+    f_fssubtype: u32,
+    f_fstypename: [16]u8,
+    f_mntonname: [1024]u8,
+    f_mntfromname: [1024]u8,
+    f_reserved: [8]u32,
+};
+
+comptime {
+    // レイアウト検証
+    std.debug.assert(@sizeOf(MacStatfs) == 2168);
+    std.debug.assert(@offsetOf(MacStatfs, "f_blocks") == 8);
+    std.debug.assert(@offsetOf(MacStatfs, "f_bavail") == 24);
+    std.debug.assert(@offsetOf(MacStatfs, "f_flags") == 64);
+    std.debug.assert(@offsetOf(MacStatfs, "f_mntonname") == 88);
+    std.debug.assert(@offsetOf(MacStatfs, "f_mntfromname") == 1112);
+}
+
+pub extern "c" fn getfsstat(buf: ?[*]MacStatfs, bufsize: i32, flags: c_int) c_int;
+
+// ── getifaddrs ─────────────────────────────────────────────────────────
+pub const AF_LINK: u8 = 18;
+
+/// macOS struct if_data (Apple Silicon 実測: sizeof=96, ifi_ibytes@40, ifi_obytes@44)
+pub const IfData = extern struct {
+    ifi_type: u8,
+    ifi_typelen: u8,
+    ifi_physical: u8,
+    ifi_addrlen: u8,
+    ifi_hdrlen: u8,
+    ifi_recvquota: u8,
+    ifi_xmitquota: u8,
+    ifi_unused1: u8,
+    ifi_mtu: u32,
+    ifi_metric: u32,
+    ifi_baudrate: u32,
+    ifi_ipackets: u32,
+    ifi_ierrors: u32,
+    ifi_opackets: u32,
+    ifi_oerrors: u32,
+    ifi_collisions: u32,
+    ifi_ibytes: u32, // @40
+    ifi_obytes: u32, // @44
+    _pad: [48]u8,
+};
+
+comptime {
+    std.debug.assert(@sizeOf(IfData) == 96);
+    std.debug.assert(@offsetOf(IfData, "ifi_ibytes") == 40);
+    std.debug.assert(@offsetOf(IfData, "ifi_obytes") == 44);
+}
+
+/// macOS struct ifaddrs
+pub const Ifaddrs = extern struct {
+    ifa_next: ?*Ifaddrs,
+    ifa_name: ?[*:0]const u8,
+    ifa_flags: u32,
+    _pad: u32, // ポインタ整列のためのパディング
+    ifa_addr: ?*anyopaque,
+    ifa_netmask: ?*anyopaque,
+    ifa_dstaddr: ?*anyopaque,
+    ifa_data: ?*anyopaque,
+};
+
+pub extern "c" fn getifaddrs(ifap: **Ifaddrs) c_int;
+pub extern "c" fn freeifaddrs(ifp: *Ifaddrs) void;
+
+// ── Mach host statistics ───────────────────────────────────────────────
+pub const mach_port_t = u32;
+pub const kern_return_t = c_int;
+pub const host_flavor_t = c_int;
+pub const mach_msg_type_number_t = u32;
+
+pub const HOST_VM_INFO64: host_flavor_t = 4;
+/// vm_statistics64_data_t は u32 を 40 個並べた 160 バイト
+pub const HOST_VM_INFO64_COUNT: mach_msg_type_number_t = 40;
+
+/// vm_statistics64 フィールドの u32 配列インデックス (Apple Silicon 実測)
+pub const VM_STAT64_FREE_IDX: usize = 0; // free_count @0
+pub const VM_STAT64_INACTIVE_IDX: usize = 2; // inactive_count @8
+pub const VM_STAT64_WIRE_IDX: usize = 3; // wire_count @12
+pub const VM_STAT64_SPECULATIVE_IDX: usize = 23; // speculative_count @92
+
+pub extern "c" fn mach_host_self() mach_port_t;
+pub extern "c" fn host_statistics64(
+    host_priv: mach_port_t,
+    flavor: host_flavor_t,
+    host_info_out: [*]u32,
+    host_info_outCnt: *mach_msg_type_number_t,
+) kern_return_t;
+
+// ── xsw_usage (vm.swapusage) ───────────────────────────────────────────
+/// struct xsw_usage (sizeof=32)
+pub const XswUsage = extern struct {
+    xsu_total: u64, // @0
+    xsu_avail: u64, // @8
+    xsu_used: u64, // @16
+    xsu_pagesize: u32, // @24
+    xsu_encrypted: u32, // @28
+};
+
+comptime {
+    std.debug.assert(@sizeOf(XswUsage) == 32);
+}


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## Issues No
close #50

## 概要
`vitals` をmacOSでネイティブ動作させるためのmacOS対応を実装しました。Linux特有の `/proc` ファイルシステムの代わりに、macOSのシステムAPI（sysctl、Mach API、getifaddrs等）を使用してメトリクスを収集します。

## 変更内容
### 追加機能
- [x] `src/utils/macos_sys.zig`: macOS extern宣言の集約ファイルを新規作成
- [x] 各コレクターにmacOS向け `collectMacos()` 関数を追加
  - CPU: `sysctlbyname("kern.cp_time")` / `"kern.cp_times"` でコア別CPU時間取得
  - Memory: `hw.memsize` + `host_statistics64(HOST_VM_INFO64)` + `vm.swapusage`
  - Disk: `getfsstat()` + `MNT_LOCAL` フラグでローカルFSのみ取得
  - Network: `getifaddrs()` + `AF_LINK` エントリから受送信バイト数取得
  - LoadAvg: `getloadavg()` で1/5/15分平均取得
  - Process: macOSスタブ（空スナップショット返却）
- [x] `snapshot.zig`: `comptime builtin.os.tag` でLinux/macOSをコンパイル時分岐

### バグ修正
- [x] `bar.zig`: `@min(usize, comptime_int=100)` が `u7` 型を返すZig 0.15.2の挙動により、`u7 * BAR_WIDTH` でinteger overflowが発生するバグを修正
  - `idx: usize` の明示型注記と `@as(usize, 100)` で正しくusize演算に

### その他の変更
- [x] `build.zig`: `macos_sys_mod` をすべてのコレクターテストモジュールの依存関係に追加

## 動作確認手順
1. macOS環境でビルド
   ```bash
   zig build
   ```

2. 確認手順
   - [x] `./zig-out/bin/vitals --once` でCPU/MEM/DISK/NET/LOAD表示を確認
   - [x] `./zig-out/bin/vitals --mini` で1行出力を確認
   - [x] `./zig-out/bin/vitals --once --json` でJSON出力を確認
   - [x] `zig build test` で全テストパスを確認

## テスト
- [x] 単体テストを追加・更新しました（macOS対応の分岐をカバー）
- [x] 手動テストを実施しました

### テスト実行結果
```
zig build test  # 全テストパス
```

## 品質チェック
- [x] `zig build` でビルド成功
- [x] `zig build test` で全テストパス
- [x] 不要なデバッグコードを削除済み

## 技術メモ
### macOS struct レイアウト (Apple Silicon ARM64実測値)
| 構造体 | sizeof | 主要フィールド |
|--------|--------|----------------|
| `struct statfs` | 2168 | f_blocks@8, f_bavail@24, f_mntonname@88 |
| `struct if_data` | 96 | ifi_ibytes@40, ifi_obytes@44 |
| `vm_statistics64_data_t` | 160 | free_count[0], inactive_count[2], speculative_count[23] |
| `struct xsw_usage` | 32 | xsu_total@0, xsu_avail@8 |